### PR TITLE
Only import alloc if alloc feature enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 #![no_std]
 #![allow(clippy::module_name_repetitions)]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(test)]


### PR DESCRIPTION
### What
Only import alloc if alloc feature enabled.

### Why
Importing alloc all the time causes the global allocator to be need to be set. But the intent of the alloc feature is to make the lib compatible with builds that don't have an allocator, of which the soroban-sdk is one.

We don't actually use escape-bytes in the soroban-sdk when building for wasm, but through a series of unfortunate events escape-bytes is still getting included because we use it for `Debug` impls in stellar-xdr that get compiled for all targets.